### PR TITLE
Work related to connection options logic

### DIFF
--- a/Sources/TDS/Connection/Requests/PreloginRequest.swift
+++ b/Sources/TDS/Connection/Requests/PreloginRequest.swift
@@ -34,7 +34,7 @@ private final class PreloginRequest: TDSRequest {
                     let message = try TDSMessage(packetType: TDSMessages.SSLKickoff(), allocator: allocator)
                     return message
                 default:
-                    throw TDSError.protocolError("PRELOGIN Error: Server does not supprt encryption.")
+                    throw TDSError.protocolError("PRELOGIN Error: Server does not support encryption.")
                 }
             }
         default:

--- a/Sources/TDS/Message/PreloginPacket.swift
+++ b/Sources/TDS/Message/PreloginPacket.swift
@@ -21,7 +21,7 @@ extension TDSMessages {
             //
             // Follows the form of:
             // - Token (1 byte)
-            // - Offset from start of packet (2 btyes)
+            // - Offset from start of packet (2 bytes)
             // - Length in # of bytes (2 bytes)
             
             // Version (Required)

--- a/Sources/TDS/Utilities/TDSError.swift
+++ b/Sources/TDS/Utilities/TDSError.swift
@@ -4,6 +4,7 @@ public enum TDSError: Error, LocalizedError, CustomStringConvertible {
     case protocolError(String)
     case connectionClosed
     case invalidCredentials
+    case invalidConnectionOptionValueLength(fieldName: String, limit: UInt16)
     
     /// See `LocalizedError`.
     public var errorDescription: String? {
@@ -20,6 +21,8 @@ public enum TDSError: Error, LocalizedError, CustomStringConvertible {
             description = "connection closed"
         case .invalidCredentials:
             description = "Invalid login credentials"
+        case .invalidConnectionOptionValueLength(let fieldName, let limit):
+            description = "The value's length for field '\(fieldName)' exceeds it's limit of '\(limit)'"
         }
         return "TDS error: \(description)"
     }

--- a/Tests/TDSTests/TDSTests.swift
+++ b/Tests/TDSTests/TDSTests.swift
@@ -1,12 +1,36 @@
 import XCTest
+import NIO
 @testable import TDS
 
 final class TDSTests: XCTestCase {
-    func testExample() {
-        
+    func testLoginOptionValidation() throws {
+        let lopremipusm129 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus gravida mauris eu tincidunt venenatis. Aliquam nec sem volutpat."
+        let auth: TDSMessages.Login7Message = TDSMessages.Login7Message(
+            hostname: lopremipusm129,
+            username: "username",
+            password: "password",
+            appName: "TDSTester",
+            serverName: "",
+            clientInterfaceName: "SwiftTDS",
+            language: "",
+            database: "database",
+            sspiData: "")
+        var buffer = ByteBufferAllocator().buffer(capacity: 255)
+        XCTAssertThrowsError(try auth.serialize(into: &buffer),
+                             "MUST FAILED on invalid filed's lenght") { (err) in
+                                let tdsErr: TDSError = err as! TDSError
+                                switch tdsErr {
+                                case let .invalidConnectionOptionValueLength(fieldName, limit):
+                                    XCTAssertEqual(fieldName, "hostname")
+                                    XCTAssertEqual(limit, 128)
+                                default:
+                                    assertionFailure("expected error was TDSError.invalidConnectionOptionValueLength")
+                                }
+                                let expectedDesc = "TDS error: The value's length for field 'hostname' exceeds it's limit of '128'"
+                                XCTAssertEqual(tdsErr.description, expectedDesc)
+        }
     }
-
     static var allTests = [
-        ("testExample", testExample),
+        ("testLoginOptionValidation", testLoginOptionValidation),
     ]
 }


### PR DESCRIPTION
### Motivation
tried to fix the TODO item.

```
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/773a62b6-ee89-4c02-9e5e-344882630aac

Login Data Validation Rules
cchHostName MUST specify at most 128 Unicode characters.
cchUserName MUST specify at most 128 Unicode characters.
cchPassword MUST specify at most 128 Unicode characters.
cchAppName MUST specify at most 128 Unicode characters.
cchServerName MUST specify at most 128 Unicode characters.
cbExtension MUST NOT exceed 255 bytes.
cchCltIntName MUST specify at most 128 Unicode characters.
cchLanguage MUST specify at most 128 Unicode characters.
cchDatabase MUST specify at most 128 Unicode characters.
cchAtchDBFile MUST specify at most 260 Unicode characters.
cchChangePassword MUST specify at most 128 Unicode characters.
```

### Modification

- added connection option validation.
- added a new error type.
-  Fixed some typos.

