### PR TITLE
Refactor row token parsing and improve error handling

### DIFF
--- a/Sources/TDS/Connection/TDSConnection+Connect.swift
+++ b/Sources/TDS/Connection/TDSConnection+Connect.swift
@@ -13,7 +13,7 @@ extension TDSConnection {
     /// Supporting the case for only encrypting login packets provides little benefit and makes it impossible to provide a default (valid) TLSConfiguration.
     public static func connect(
         to socketAddress: SocketAddress,
-        tlsConfiguration: TLSConfiguration? = .forClient(),
+        tlsConfiguration: TLSConfiguration? = .makeClientConfiguration(),
         serverHostname: String? = nil,
         on eventLoop: EventLoop
     ) -> EventLoopFuture<TDSConnection> {

--- a/Sources/TDS/Data/TDSData.swift
+++ b/Sources/TDS/Data/TDSData.swift
@@ -13,7 +13,7 @@ public struct TDSData: CustomStringConvertible, CustomDebugStringConvertible {
     }
 
     public var description: String {
-        guard let value = self.value else {
+        guard let value, value.readableBytes != 0 else {
             return "<null>"
         }
 
@@ -35,7 +35,7 @@ public struct TDSData: CustomStringConvertible, CustomDebugStringConvertible {
         case .float, .floatn, .numeric, .numericLegacy, .decimal, .decimalLegacy, .smallMoney, .money, .moneyn:
             description = self.double?.description
         case .smallDateTime, .datetime, .datetimen, .date, .time, .datetime2, .datetimeOffset:
-            fatalError("Unimplemented")
+            description = self.date?.description
         case .charLegacy, .varcharLegacy, .char, .varchar, .nvarchar, .nchar, .text, .nText:
             description = self.string?.description
         case .binaryLegacy, .varbinaryLegacy, .varbinary, .binary:
@@ -61,7 +61,7 @@ public struct TDSData: CustomStringConvertible, CustomDebugStringConvertible {
             }
         }
 
-        if let description = description {
+        if let description {
             return description
         } else {
             return "0x" + value.readableBytesView.hexdigest()

--- a/Sources/TDS/Token/TDSToken.swift
+++ b/Sources/TDS/Token/TDSToken.swift
@@ -121,6 +121,16 @@ public enum TDSTokens {
             var textPointer: [Byte]
             var timestamp: [Byte]
             var data: ByteBuffer
+            
+            init(
+                data: ByteBuffer,
+                textPointer: [Byte] = [],
+                timestamp: [Byte] = []
+            ) {
+                self.data = data
+                self.textPointer = textPointer
+                self.timestamp = timestamp
+            }
         }
     }
 

--- a/Sources/TDS/Token/TDSTokenParser+Row.swift
+++ b/Sources/TDS/Token/TDSTokenParser+Row.swift
@@ -1,51 +1,154 @@
 extension TDSTokenParser {
     public static func parseRowToken(from buffer: inout ByteBuffer, with colMetadata: TDSTokens.ColMetadataToken) throws -> TDSTokens.RowToken {
-        var colData: [TDSTokens.RowToken.ColumnData] = []
+        let allocator = ByteBufferAllocator()
 
-        // TODO: Handle textpointer and timestamp for certain types
-        for col in colMetadata.colData {
-
-            var length: Int
-            switch col.dataType {
-            case .sqlVariant, .nText, .text, .image:
-                guard let len = buffer.readLongLen() else {
-                    throw TDSError.protocolError("Error while reading length")
-                }
-                length = Int(len)
-            case .char, .varchar, .nchar, .nvarchar, .binary, .varbinary:
-                guard let len = buffer.readUShortCharBinLen() else {
-                    throw TDSError.protocolError("Error while reading length")
-                }
-                length = Int(len)
-            case .date:
-                length = 3
-            case .tinyInt, .bit:
-                length = 1
-            case .smallInt:
-                length = 2
-            case .int, .smallDateTime, .real, .smallMoney:
-                length = 4
-            case .money, .datetime, .float, .bigInt:
-                length = 8
-            case .null:
-                length = 0
-            default:
-                guard let len = buffer.readByteLen() else {
-                    throw TDSError.protocolError("Error while reading length.")
-                }
-                length = Int(len)
-            }
-
-            guard
-                let data = buffer.readSlice(length: Int(length))
-                else {
-                    throw TDSError.protocolError("Error while reading row data")
-            }
-
-            colData.append(TDSTokens.RowToken.ColumnData(textPointer: [], timestamp: [], data: data))
+        enum ColumnReadKind {
+            case fixed(Int)
+            case variable(nullMarker: UInt16)
+            case plp
+            case numeric
         }
 
-        let token = TDSTokens.RowToken(colData: colData)
-        return token
+        func readSlice(_ buf: inout ByteBuffer, length: Int) throws -> ByteBuffer {
+            guard let slice = buf.readSlice(length: length) else { throw TDSError.needMoreData }
+            var copy = allocator.buffer(capacity: slice.readableBytes)
+            var mutable = slice
+            copy.writeBuffer(&mutable)
+            return copy
+        }
+
+        func readVariableLength(_ buf: inout ByteBuffer, nullMarker: UInt16) throws -> ByteBuffer? {
+            guard let len: UInt16 = buf.readInteger(endianness: .little, as: UInt16.self) else { throw TDSError.needMoreData }
+            if len == nullMarker { return nil }
+            return try readSlice(&buf, length: Int(len))
+        }
+
+        func readPLP(_ buf: inout ByteBuffer) throws -> ByteBuffer? {
+            // PLP format:
+            // UINT64 totalLength
+            // if totalLength == 0xFFFFFFFFFFFFFFFF => NULL
+            // else: repeated (UINT32 chunkLength, chunk data) until chunkLength == 0
+
+            guard let totalLength: UInt64 = buf.readInteger(endianness: .little, as: UInt64.self) else {
+                throw TDSError.needMoreData
+            }
+
+            // NULL PLP value
+            if totalLength == UInt64.max {
+                return nil
+            }
+
+            var result = allocator.buffer(capacity: Int(min(totalLength, UInt64(Int.max))))
+
+            while true {
+                guard let chunkLength: UInt32 = buf.readInteger(endianness: .little, as: UInt32.self) else {
+                    throw TDSError.needMoreData
+                }
+
+                if chunkLength == 0 {
+                    break
+                }
+
+                let slice = try readSlice(&buf, length: Int(chunkLength))
+                var mutable = slice
+                result.writeBuffer(&mutable)
+            }
+
+            return result
+        }
+
+        func readKind(for column: TDSTokens.ColMetadataToken.ColumnData) -> ColumnReadKind {
+            switch column.dataType {
+            case .tinyInt: return .fixed(1)
+            case .smallInt: return .fixed(2)
+            case .int: return .fixed(4)
+            case .bigInt: return .fixed(8)
+            case .bit: return .fixed(1)
+            case .real: return .fixed(4)
+            case .float: return .fixed(8)
+            case .guid: return .fixed(16)
+            case .numeric, .decimal: return .numeric
+            case .intn, .floatn: return .numeric
+            case .nvarchar, .nchar, .varchar, .char:
+                if column.length >= 0xFFFF {
+                    return .plp
+                }
+                return .variable(nullMarker: UInt16.max)
+            case .varbinary, .binary, .image, .xml: return .variable(nullMarker: UInt16.max)
+            default:
+                if let fixed = expectedFixedSize(of: column) {
+                    return .fixed(fixed)
+                }
+                return .variable(nullMarker: UInt16.max)
+            }
+        }
+
+        func parseColumnData(
+            _ buf: inout ByteBuffer,
+            column: TDSTokens.ColMetadataToken.ColumnData
+        ) throws -> TDSTokens.RowToken.ColumnData {
+
+            switch readKind(for: column) {
+
+            case .fixed(let size):
+                return TDSTokens.RowToken.ColumnData(
+                    data: try readSlice(&buf, length: size)
+                )
+
+            case .variable(let nullMarker):
+                if let payload = try readVariableLength(&buf, nullMarker: nullMarker) {
+                    return TDSTokens.RowToken.ColumnData(data: payload)
+                }
+                return TDSTokens.RowToken.ColumnData(data: allocator.buffer(capacity: 0))
+
+            case .plp:
+                if let plp = try readPLP(&buf) {
+                    return TDSTokens.RowToken.ColumnData(data: plp)
+                }
+                return TDSTokens.RowToken.ColumnData(data: allocator.buffer(capacity: 0))
+
+            case .numeric:
+                guard let length: UInt8 = buf.readInteger() else {
+                    throw TDSError.needMoreData
+                }
+
+                if length == 0 {
+                    return TDSTokens.RowToken.ColumnData(data: allocator.buffer(capacity: 0))
+                }
+
+                let payload = try readSlice(&buf, length: Int(length))
+                return TDSTokens.RowToken.ColumnData(data: payload)
+            }
+        }
+
+        func expectedFixedSize(of column: TDSTokens.ColMetadataToken.ColumnData) -> Int? {
+            switch column.dataType {
+            case .tinyInt, .bit: 1
+            case .smallInt: 2
+            case .int, .real, .smallMoney, .smallDateTime: 4
+            case .bigInt, .float, .money, .datetime: 8
+            case .date: 3
+            case .time: timePayloadLength(scale: column.scale)
+            case .datetime2: timePayloadLength(scale: column.scale) + 3
+            case .datetimeOffset: timePayloadLength(scale: column.scale) + 5
+            case .guid: 16
+            default: nil
+            }
+        }
+
+        func timePayloadLength(scale: Int?) -> Int {
+            switch max(0, min(scale ?? 7, 7)) {
+            case 0...2: 3
+            case 3...4: 4
+            default: 5
+            }
+        }
+
+        var colData: [TDSTokens.RowToken.ColumnData] = []
+        for column in colMetadata.colData {
+            colData.append(try parseColumnData(&buffer, column: column))
+        }
+
+        return TDSTokens.RowToken(colData: colData)
     }
 }

--- a/Sources/TDS/Utilities/TDSError.swift
+++ b/Sources/TDS/Utilities/TDSError.swift
@@ -4,12 +4,13 @@ public enum TDSError: Error, LocalizedError, CustomStringConvertible {
     case protocolError(String)
     case connectionClosed
     case invalidCredentials
-    
+    case needMoreData
+
     /// See `LocalizedError`.
     public var errorDescription: String? {
         return self.description
     }
-    
+
     /// See `CustomStringConvertible`.
     public var description: String {
         let description: String
@@ -20,6 +21,8 @@ public enum TDSError: Error, LocalizedError, CustomStringConvertible {
             description = "connection closed"
         case .invalidCredentials:
             description = "Invalid login credentials"
+        case .needMoreData:
+            description = "need more data"
         }
         return "TDS error: \(description)"
     }


### PR DESCRIPTION
Refactors the RowToken parser to handle more data types, including PLP and variable-length columns, and introduces a new TDSError.needMoreData case for partial buffer reads. Also updates TDSData to improve description handling for date types, adds an initializer to RowToken.ColumnData, and changes the default TLS configuration method.